### PR TITLE
Bugfix for listing vulnerable server in message body

### DIFF
--- a/SMTPTester.py
+++ b/SMTPTester.py
@@ -154,8 +154,8 @@ def internal_test(smtp_targets, port, fromaddr, toaddr, data, subject, debug):
 
     for target in smtp_targets:
         LOGGER.info("[*] Checking host %s:%s for internal spoofing", target, str(port))
-        data += "\nVulnerable server is: %s" % target
         try:
+            data += "\nVulnerable server is: %s" % target
             if fromaddr and toaddr:  # making sure we have both from and to addresses
                 from_domain = fromaddr.split('@').pop()  # getting the domain name from the address
                 to_domain = toaddr.split('@').pop()  # getting the domain name from the address


### PR DESCRIPTION
Moving the `data` variable that's appending to the message body and listing the vulnerable server to within the try statement to avoid all IPs within the for loop which were tested up to that point being added to the message body